### PR TITLE
Budget alert when adding an expense

### DIFF
--- a/src/main/java/seedu/duke/BudgetChecker.java
+++ b/src/main/java/seedu/duke/BudgetChecker.java
@@ -1,0 +1,57 @@
+package seedu.duke;
+
+import java.util.logging.Logger;
+
+/**
+ * Checks total spending against the monthly budget and returns an appropriate alert message.
+ * Used after each add command to warn the user if they are approaching or exceeding their budget.
+ */
+public class BudgetChecker {
+
+    private static final Logger logger = Logger.getLogger(BudgetChecker.class.getName());
+    private static final double WARNING_THRESHOLD = 0.9;
+
+    static {
+        logger.setUseParentHandlers(false);
+    }
+
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private BudgetChecker() {
+        // Utility class should not be instantiated
+    }
+
+    /**
+     * Checks the current spending against the budget and prints a warning or alert if needed.
+     * Does nothing if no budget has been set or spending is below 90% of the budget.
+     *
+     * @param expenses the expense list containing budget and expense data
+     * @param ui the UI used to display messages
+     */
+    public static void check(ExpenseList expenses, Ui ui) {
+        assert expenses != null : "ExpenseList should not be null";
+        assert ui != null : "Ui should not be null";
+
+        if (!expenses.hasBudget()) {
+            logger.fine("No budget set, skipping budget check.");
+            return;
+        }
+
+        double totalSpent = expenses.getTotal();
+        double budget = expenses.getBudget();
+
+        assert budget > 0 : "Budget should be positive when hasBudget() returns true";
+
+        double usageRatio = totalSpent / budget;
+
+        logger.info(String.format("Budget check: spent=%.2f, budget=%.2f, ratio=%.2f",
+                totalSpent, budget, usageRatio));
+
+        if (totalSpent > budget) {
+            ui.showBudgetAlert(totalSpent, budget);
+        } else if (usageRatio >= WARNING_THRESHOLD) {
+            ui.showBudgetWarning(totalSpent, budget);
+        }
+    }
+}

--- a/src/main/java/seedu/duke/Ui.java
+++ b/src/main/java/seedu/duke/Ui.java
@@ -508,6 +508,28 @@ public class Ui {
     }
 
     /**
+     * Displays a warning when spending is at or above 90% of the budget.
+     *
+     * @param totalSpent the current total spent
+     * @param budget the monthly budget limit
+     */
+    public void showBudgetWarning(double totalSpent, double budget) {
+        System.out.printf(" [WARNING] You are close to your monthly budget! ($%.2f / $%.2f used)%n",
+                totalSpent, budget);
+    }
+
+    /**
+     * Displays an alert when spending has exceeded the budget.
+     *
+     * @param totalSpent the current total spent
+     * @param budget the monthly budget limit
+     */
+    public void showBudgetAlert(double totalSpent, double budget) {
+        System.out.printf(" [ALERT] You have exceeded your monthly budget! ($%.2f spent, budget is $%.2f)%n",
+                totalSpent, budget);
+    }
+
+    /**
      * Displays an error message to the user.
      *
      * @param message the error message to display

--- a/src/main/java/seedu/duke/command/AddCommand.java
+++ b/src/main/java/seedu/duke/command/AddCommand.java
@@ -3,6 +3,7 @@ package seedu.duke.command;
 import java.time.LocalDate;
 import java.util.logging.Logger;
 
+import seedu.duke.BudgetChecker;
 import seedu.duke.Expense;
 import seedu.duke.ExpenseList;
 import seedu.duke.SpendTrackException;
@@ -78,6 +79,7 @@ public class AddCommand extends Command {
         Expense expense = new Expense(description, amount, category, date, isRecurring);
         expenses.addExpense(expense);
         ui.showAddSuccess(expense);
+        BudgetChecker.check(expenses, ui);
         logger.info("Expense added successfully. Total expenses: " + expenses.size());
     }
 

--- a/src/test/java/seedu/duke/BudgetCheckerTest.java
+++ b/src/test/java/seedu/duke/BudgetCheckerTest.java
@@ -1,0 +1,169 @@
+package seedu.duke;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BudgetCheckerTest {
+
+    private static final PrintStream ORIGINAL_OUT = System.out;
+
+    private ExpenseList expenses;
+    private Ui ui;
+    private ByteArrayOutputStream outputStream;
+
+    @BeforeEach
+    void setUp() {
+        expenses = new ExpenseList();
+        ui = new Ui();
+        outputStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStream));
+    }
+
+    @AfterEach
+    void restoreSystemOut() {
+        System.setOut(ORIGINAL_OUT);
+    }
+
+    @Test
+    void check_noBudgetSet_noOutput() {
+        expenses.addExpense(new Expense("Lunch", 50.00, "Food", LocalDate.now()));
+
+        BudgetChecker.check(expenses, ui);
+
+        String output = outputStream.toString();
+        assertFalse(output.contains("[WARNING]"));
+        assertFalse(output.contains("[ALERT]"));
+    }
+
+    @Test
+    void check_spendingUnderNinetyPercent_noOutput() {
+        expenses.setBudget(100.00);
+        expenses.addExpense(new Expense("Lunch", 50.00, "Food", LocalDate.now()));
+
+        BudgetChecker.check(expenses, ui);
+
+        String output = outputStream.toString();
+        assertFalse(output.contains("[WARNING]"));
+        assertFalse(output.contains("[ALERT]"));
+    }
+
+    @Test
+    void check_spendingAtExactlyNinetyPercent_showsWarning() {
+        expenses.setBudget(100.00);
+        expenses.addExpense(new Expense("Lunch", 90.00, "Food", LocalDate.now()));
+
+        BudgetChecker.check(expenses, ui);
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("[WARNING]"));
+        assertTrue(output.contains("$90.00"));
+        assertTrue(output.contains("$100.00"));
+    }
+
+    @Test
+    void check_spendingBetweenNinetyAndHundredPercent_showsWarning() {
+        expenses.setBudget(100.00);
+        expenses.addExpense(new Expense("Lunch", 95.00, "Food", LocalDate.now()));
+
+        BudgetChecker.check(expenses, ui);
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("[WARNING]"));
+        assertFalse(output.contains("[ALERT]"));
+    }
+
+    @Test
+    void check_spendingAtExactlyBudget_showsWarning() {
+        expenses.setBudget(100.00);
+        expenses.addExpense(new Expense("Lunch", 100.00, "Food", LocalDate.now()));
+
+        BudgetChecker.check(expenses, ui);
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("[WARNING]"));
+        assertFalse(output.contains("[ALERT]"));
+    }
+
+    @Test
+    void check_spendingExceedsBudget_showsAlert() {
+        expenses.setBudget(100.00);
+        expenses.addExpense(new Expense("Lunch", 120.00, "Food", LocalDate.now()));
+
+        BudgetChecker.check(expenses, ui);
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("[ALERT]"));
+        assertTrue(output.contains("$120.00"));
+        assertTrue(output.contains("$100.00"));
+    }
+
+    @Test
+    void check_multipleExpensesExceedBudget_showsAlert() {
+        expenses.setBudget(100.00);
+        expenses.addExpense(new Expense("Lunch", 60.00, "Food", LocalDate.now()));
+        expenses.addExpense(new Expense("Dinner", 50.00, "Food", LocalDate.now()));
+
+        BudgetChecker.check(expenses, ui);
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("[ALERT]"));
+        assertTrue(output.contains("$110.00"));
+    }
+
+    @Test
+    void check_multipleExpensesTriggerWarning_showsWarning() {
+        expenses.setBudget(100.00);
+        expenses.addExpense(new Expense("Lunch", 50.00, "Food", LocalDate.now()));
+        expenses.addExpense(new Expense("Dinner", 42.00, "Food", LocalDate.now()));
+
+        BudgetChecker.check(expenses, ui);
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("[WARNING]"));
+        assertTrue(output.contains("$92.00"));
+    }
+
+    @Test
+    void check_spendingJustBelowNinetyPercent_noOutput() {
+        expenses.setBudget(100.00);
+        expenses.addExpense(new Expense("Lunch", 89.99, "Food", LocalDate.now()));
+
+        BudgetChecker.check(expenses, ui);
+
+        String output = outputStream.toString();
+        assertFalse(output.contains("[WARNING]"));
+        assertFalse(output.contains("[ALERT]"));
+    }
+
+    @Test
+    void check_zeroExpenses_noOutput() {
+        expenses.setBudget(100.00);
+
+        BudgetChecker.check(expenses, ui);
+
+        String output = outputStream.toString();
+        assertFalse(output.contains("[WARNING]"));
+        assertFalse(output.contains("[ALERT]"));
+    }
+
+    @Test
+    void check_budgetResetAfterExceeding_noOutput() {
+        expenses.setBudget(100.00);
+        expenses.addExpense(new Expense("Lunch", 120.00, "Food", LocalDate.now()));
+        expenses.resetBudget();
+
+        BudgetChecker.check(expenses, ui);
+
+        String output = outputStream.toString();
+        assertFalse(output.contains("[WARNING]"));
+        assertFalse(output.contains("[ALERT]"));
+    }
+}


### PR DESCRIPTION
## Summary
- Added `BudgetChecker` utility class that checks total spending against the monthly budget after each `add` command
- Shows `[WARNING]` when spending reaches 90% of budget, `[ALERT]` when exceeded
- No message if no budget is set or spending is under 90%
- Added 11 JUnit tests covering all boundary conditions

Fixes #50