### PR TITLE
Undo last mutating command

### DIFF
--- a/src/main/java/seedu/duke/ExpenseList.java
+++ b/src/main/java/seedu/duke/ExpenseList.java
@@ -179,4 +179,18 @@ public class ExpenseList {
         this.budget = budget;
         logger.info("Budget restored to: " + budget);
     }
+
+    /**
+     * Replaces the current expenses and budget with the given snapshot data.
+     * Used by UndoManager to restore a previous state.
+     *
+     * @param restoredExpenses the list of expenses to restore
+     * @param restoredBudget the budget amount to restore
+     */
+    public void restoreFrom(ArrayList<Expense> restoredExpenses, double restoredBudget) {
+        assert restoredExpenses != null : "Restored expenses should not be null";
+        this.expenses = new ArrayList<>(restoredExpenses);
+        this.budget = restoredBudget;
+        logger.info("Expenses restored: " + expenses.size() + " entries, budget=" + budget);
+    }
 }

--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -19,6 +19,7 @@ import seedu.duke.command.TotalCommand;
 import seedu.duke.command.EditCommand;
 import seedu.duke.command.BudgetResetCommand;
 import seedu.duke.command.BudgetHistoryCommand;
+import seedu.duke.command.UndoCommand;
 
 /**
  * Parses user input into commands.
@@ -41,12 +42,25 @@ public class Parser {
 
     /**
      * Parses the user input and returns the corresponding command.
+     * Uses a null UndoManager, so undo command is unavailable.
      *
      * @param input the raw user input string
      * @return the parsed Command
      * @throws SpendTrackException if input is invalid
      */
     public static Command parse(String input) throws SpendTrackException {
+        return parse(input, null);
+    }
+
+    /**
+     * Parses the user input and returns the corresponding command.
+     *
+     * @param input the raw user input string
+     * @param undoManager the undo manager for creating undo commands
+     * @return the parsed Command
+     * @throws SpendTrackException if input is invalid
+     */
+    public static Command parse(String input, UndoManager undoManager) throws SpendTrackException {
         assert input != null : "Input to parser should not be null";
 
         String trimmed = input.trim();
@@ -88,6 +102,11 @@ public class Parser {
             return parseBudgetCommand(parts.length > 1 ? parts[1] : "");
         case "remaining":
             return new RemainingCommand();
+        case "undo":
+            if (undoManager == null) {
+                throw new SpendTrackException("Undo is not available.");
+            }
+            return new UndoCommand(undoManager);
         case "summary":
             return new SummaryCommand();
         case "help":

--- a/src/main/java/seedu/duke/SpendTrack.java
+++ b/src/main/java/seedu/duke/SpendTrack.java
@@ -20,11 +20,13 @@ public class SpendTrack {
     private final Ui ui;
     private final ExpenseList expenses;
     private final Storage storage;
+    private final UndoManager undoManager;
 
     public SpendTrack() {
         ui = new Ui();
         expenses = new ExpenseList();
         storage = new Storage(DATA_FILE_PATH);
+        undoManager = new UndoManager();
     }
 
     /**
@@ -41,7 +43,11 @@ public class SpendTrack {
         while (isRunning) {
             String input = ui.readCommand();
             try {
-                Command command = Parser.parse(input);
+                Command command = Parser.parse(input, undoManager);
+                if (command.mutatesData() && !(command instanceof
+                        seedu.duke.command.UndoCommand)) {
+                    undoManager.saveSnapshot(expenses);
+                }
                 command.execute(expenses, ui);
                 if (command.mutatesData()) {
                     storage.save(expenses);

--- a/src/main/java/seedu/duke/UndoManager.java
+++ b/src/main/java/seedu/duke/UndoManager.java
@@ -1,0 +1,92 @@
+package seedu.duke;
+
+import java.util.ArrayList;
+import java.util.logging.Logger;
+
+/**
+ * Manages undo functionality by storing a snapshot of the expense list
+ * before each mutating command. Supports single-level undo only.
+ */
+public class UndoManager {
+
+    private static final Logger logger = Logger.getLogger(UndoManager.class.getName());
+
+    static {
+        logger.setUseParentHandlers(false);
+    }
+
+    private ArrayList<Expense> snapshot;
+    private double snapshotBudget;
+    private boolean hasSnapshot;
+
+    /**
+     * Constructs an UndoManager with no stored snapshot.
+     */
+    public UndoManager() {
+        this.snapshot = null;
+        this.snapshotBudget = 0.0;
+        this.hasSnapshot = false;
+    }
+
+    /**
+     * Saves a deep copy of the current expense list and budget as a snapshot.
+     * Overwrites any previously stored snapshot.
+     *
+     * @param expenses the expense list to snapshot
+     */
+    public void saveSnapshot(ExpenseList expenses) {
+        assert expenses != null : "ExpenseList should not be null when saving snapshot";
+
+        snapshot = deepCopyExpenses(expenses.getExpenses());
+        snapshotBudget = expenses.getBudget();
+        hasSnapshot = true;
+        logger.info("Snapshot saved: " + snapshot.size() + " expenses, budget=" + snapshotBudget);
+    }
+
+    /**
+     * Restores the expense list from the stored snapshot.
+     * After restoring, the snapshot is consumed and cannot be used again.
+     *
+     * @param expenses the expense list to restore into
+     * @return true if undo was successful, false if no snapshot available
+     */
+    public boolean undo(ExpenseList expenses) {
+        assert expenses != null : "ExpenseList should not be null when undoing";
+
+        if (!hasSnapshot) {
+            logger.info("Undo attempted but no snapshot available.");
+            return false;
+        }
+
+        expenses.restoreFrom(snapshot, snapshotBudget);
+        hasSnapshot = false;
+        snapshot = null;
+        logger.info("Snapshot restored successfully.");
+        return true;
+    }
+
+    /**
+     * Returns true if a snapshot is available for undo.
+     *
+     * @return true if undo is possible
+     */
+    public boolean hasSnapshot() {
+        return hasSnapshot;
+    }
+
+    private ArrayList<Expense> deepCopyExpenses(ArrayList<Expense> original) {
+        assert original != null : "Original expense list should not be null";
+
+        ArrayList<Expense> copy = new ArrayList<>();
+        for (Expense expense : original) {
+            copy.add(new Expense(
+                    expense.getDescription(),
+                    expense.getAmount(),
+                    expense.getCategory(),
+                    expense.getDate(),
+                    expense.isRecurring()
+            ));
+        }
+        return copy;
+    }
+}

--- a/src/main/java/seedu/duke/command/UndoCommand.java
+++ b/src/main/java/seedu/duke/command/UndoCommand.java
@@ -1,0 +1,61 @@
+package seedu.duke.command;
+
+import java.util.logging.Logger;
+
+import seedu.duke.ExpenseList;
+import seedu.duke.Ui;
+import seedu.duke.UndoManager;
+
+/**
+ * Undoes the last mutating command by restoring the previous expense list snapshot.
+ */
+public class UndoCommand extends Command {
+
+    private static final Logger logger = Logger.getLogger(UndoCommand.class.getName());
+
+    static {
+        logger.setUseParentHandlers(false);
+    }
+
+    private final UndoManager undoManager;
+
+    /**
+     * Constructs an UndoCommand with the given UndoManager.
+     *
+     * @param undoManager the undo manager holding the snapshot
+     */
+    public UndoCommand(UndoManager undoManager) {
+        assert undoManager != null : "UndoManager should not be null";
+        this.undoManager = undoManager;
+    }
+
+    /**
+     * Executes the undo by restoring the expense list from the last snapshot.
+     *
+     * @param expenses the expense list to restore
+     * @param ui the UI for displaying output
+     */
+    @Override
+    public void execute(ExpenseList expenses, Ui ui) {
+        assert expenses != null : "ExpenseList should not be null";
+        assert ui != null : "Ui should not be null";
+
+        boolean isUndone = undoManager.undo(expenses);
+        if (isUndone) {
+            System.out.println("____________________________________________________________");
+            System.out.println(" Last command undone successfully.");
+            System.out.println("____________________________________________________________");
+            logger.info("Undo executed successfully.");
+        } else {
+            System.out.println("____________________________________________________________");
+            System.out.println(" Nothing to undo.");
+            System.out.println("____________________________________________________________");
+            logger.info("Nothing to undo.");
+        }
+    }
+
+    @Override
+    public boolean mutatesData() {
+        return true;
+    }
+}

--- a/src/test/java/seedu/duke/command/UndoCommandTest.java
+++ b/src/test/java/seedu/duke/command/UndoCommandTest.java
@@ -1,0 +1,130 @@
+package seedu.duke.command;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.time.LocalDate;
+
+import seedu.duke.Expense;
+import seedu.duke.ExpenseList;
+import seedu.duke.SpendTrackException;
+import seedu.duke.Ui;
+import seedu.duke.UndoManager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UndoCommandTest {
+
+    private static final PrintStream ORIGINAL_OUT = System.out;
+
+    private ExpenseList expenses;
+    private Ui ui;
+    private UndoManager undoManager;
+    private ByteArrayOutputStream outputStream;
+
+    @BeforeEach
+    void setUp() {
+        expenses = new ExpenseList();
+        ui = new Ui();
+        undoManager = new UndoManager();
+        outputStream = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outputStream));
+    }
+
+    @AfterEach
+    void restoreSystemOut() {
+        System.setOut(ORIGINAL_OUT);
+    }
+
+    @Test
+    void execute_undoAfterAdd_removesAddedExpense() throws SpendTrackException {
+        expenses.addExpense(new Expense("Old", 5.00, "Food", LocalDate.now()));
+        undoManager.saveSnapshot(expenses);
+        expenses.addExpense(new Expense("New", 10.00, "Food", LocalDate.now()));
+        assertEquals(2, expenses.size());
+
+        new UndoCommand(undoManager).execute(expenses, ui);
+
+        assertEquals(1, expenses.size());
+        assertEquals("Old", expenses.getExpense(0).getDescription());
+        assertTrue(outputStream.toString().contains("Last command undone successfully."));
+    }
+
+    @Test
+    void execute_undoAfterDelete_restoresDeletedExpense() throws SpendTrackException {
+        expenses.addExpense(new Expense("Lunch", 10.00, "Food", LocalDate.now()));
+        undoManager.saveSnapshot(expenses);
+        expenses.deleteExpense(0);
+        assertEquals(0, expenses.size());
+
+        new UndoCommand(undoManager).execute(expenses, ui);
+
+        assertEquals(1, expenses.size());
+        assertEquals("Lunch", expenses.getExpense(0).getDescription());
+    }
+
+    @Test
+    void execute_nothingToUndo_showsMessage() {
+        new UndoCommand(undoManager).execute(expenses, ui);
+
+        String output = outputStream.toString();
+        assertTrue(output.contains("Nothing to undo."));
+    }
+
+    @Test
+    void execute_twoConsecutiveUndos_secondShowsNothingToUndo() {
+        expenses.addExpense(new Expense("Lunch", 10.00, "Food", LocalDate.now()));
+        undoManager.saveSnapshot(expenses);
+        expenses.addExpense(new Expense("Dinner", 20.00, "Food", LocalDate.now()));
+
+        new UndoCommand(undoManager).execute(expenses, ui);
+        new UndoCommand(undoManager).execute(expenses, ui);
+
+        assertEquals(1, expenses.size());
+        assertTrue(outputStream.toString().contains("Nothing to undo."));
+    }
+
+    @Test
+    void execute_undoRestoresBudget() {
+        expenses.setBudget(500.00);
+        undoManager.saveSnapshot(expenses);
+        expenses.setBudget(1000.00);
+
+        new UndoCommand(undoManager).execute(expenses, ui);
+
+        assertEquals(500.00, expenses.getBudget(), 0.01);
+    }
+
+    @Test
+    void execute_undoAfterEdit_restoresOriginalExpense() {
+        expenses.addExpense(new Expense("Lunch", 10.00, "Food", LocalDate.now()));
+        undoManager.saveSnapshot(expenses);
+        expenses.getExpense(0).setAmount(99.00);
+
+        new UndoCommand(undoManager).execute(expenses, ui);
+
+        assertEquals(10.00, expenses.getExpense(0).getAmount(), 0.01);
+    }
+
+    @Test
+    void execute_snapshotIsDeepCopy_originalNotAffected() {
+        expenses.addExpense(new Expense("Lunch", 10.00, "Food", LocalDate.now()));
+        undoManager.saveSnapshot(expenses);
+        expenses.getExpense(0).setDescription("Modified");
+        expenses.addExpense(new Expense("Dinner", 20.00, "Food", LocalDate.now()));
+
+        new UndoCommand(undoManager).execute(expenses, ui);
+
+        assertEquals(1, expenses.size());
+        assertEquals("Lunch", expenses.getExpense(0).getDescription());
+    }
+
+    @Test
+    void mutatesData_returnsTrue() {
+        assertTrue(new UndoCommand(undoManager).mutatesData());
+    }
+}


### PR DESCRIPTION
## Summary
- Added `UndoManager` that saves a deep copy snapshot of the expense list before each mutating command
- Added `UndoCommand` that restores the snapshot (single-level undo)
- Snapshot covers both expenses and budget state
- Two consecutive undos: second prints "Nothing to undo"
- Added 8 JUnit tests covering undo after add/delete/edit, budget restore, deep copy integrity, and edge cases

Fixes #52