### PR TITLE
feat: Add sort command for expenses

### DIFF
--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
-
+import seedu.duke.command.SortCommand;
 import seedu.duke.command.AddCommand;
 import seedu.duke.command.BudgetCommand;
 import seedu.duke.command.Command;
@@ -109,6 +109,8 @@ public class Parser {
             return new UndoCommand(undoManager);
         case "summary":
             return new SummaryCommand();
+        case "sort":
+            return new SortCommand();
         case "help":
             return new HelpCommand();
         case "bye":

--- a/src/main/java/seedu/duke/command/SortCommand.java
+++ b/src/main/java/seedu/duke/command/SortCommand.java
@@ -1,0 +1,27 @@
+package seedu.duke.command;
+
+import seedu.duke.Expense;
+import seedu.duke.ExpenseList;
+import seedu.duke.Ui;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class SortCommand extends Command {
+
+    @Override
+    public void execute(ExpenseList expenses, Ui ui) {
+        List<Expense> sorted = new ArrayList<>(expenses.getExpenses());
+
+        sorted.sort(Comparator.comparingDouble(Expense::getAmount).reversed());
+
+        System.out.println("Here are your expenses sorted by amount:");
+
+        int index = 1;
+        for (Expense e : sorted) {
+            System.out.println(index + ". " + e.toString());
+            index++;
+        }
+    }
+}


### PR DESCRIPTION
Implement a sort command that allows users to view their expenses in a sorted order.

The command should sort the current list of expenses based on a specified field. For this iteration, the sorting will be done by amount in descending order, so that higher expenses appear first.

This improves usability by helping users quickly identify their largest expenses.

Closes #56 