### PR TITLE
fix: list and budget commands now reject extra tokens

### DIFF
--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -466,6 +466,10 @@ public class Parser {
         }
         try {
             double amount = Double.parseDouble(trimmed);
+            if (!Double.isFinite(amount)) {
+                throw new SpendTrackException(
+                        "budget requires a number. Usage: budget <amount>");
+            }
             return new BudgetCommand(amount);
         } catch (NumberFormatException e) {
             throw new SpendTrackException(

--- a/src/main/java/seedu/duke/Parser.java
+++ b/src/main/java/seedu/duke/Parser.java
@@ -106,9 +106,13 @@ public class Parser {
         case "total":
             return new TotalCommand();
         case "list":
-            if (parts.length > 1
-                    && parts[1].trim().toLowerCase().startsWith("recurring")) {
-                return new ListCommand(true);
+            if (parts.length > 1) {
+                String listArg = parts[1].trim().toLowerCase();
+                if (listArg.equals("recurring")) {
+                    return new ListCommand(true);
+                }
+                throw new SpendTrackException(
+                        "Invalid list option. Usage: list OR list recurring");
             }
             return new ListCommand();
         case "budget":
@@ -443,23 +447,29 @@ public class Parser {
     }
 
     private static Command parseBudgetCommand(String args) throws SpendTrackException {
-        if (args.trim().equalsIgnoreCase("reset")) {
+        String trimmed = args.trim();
+        if (trimmed.equalsIgnoreCase("reset")) {
             return new BudgetResetCommand();
         }
-        if (args.trim().equalsIgnoreCase("history")) {
+        if (trimmed.equalsIgnoreCase("history")) {
             return new BudgetHistoryCommand();
         }
-        if (args.trim().isEmpty()) {
-            throw new SpendTrackException("budget requires a number. Usage: budget <amount>");
+        if (trimmed.isEmpty()) {
+            throw new SpendTrackException(
+                    "budget requires a number. Usage: budget <amount>");
+        }
+        if (trimmed.toLowerCase().startsWith("reset")) {
+            throw new SpendTrackException("Usage: budget reset");
+        }
+        if (trimmed.toLowerCase().startsWith("history")) {
+            throw new SpendTrackException("Usage: budget history");
         }
         try {
-            double amount = Double.parseDouble(args.trim());
-            if (!Double.isFinite(amount)) {
-                throw new SpendTrackException("Budget must be a finite number. Usage: budget <amount>");
-            }
+            double amount = Double.parseDouble(trimmed);
             return new BudgetCommand(amount);
         } catch (NumberFormatException e) {
-            throw new SpendTrackException("budget requires a number. Usage: budget <amount>");
+            throw new SpendTrackException(
+                    "budget requires a number. Usage: budget <amount>");
         }
     }
 


### PR DESCRIPTION
Here's the PR description:

Title: fix: list and budget commands reject extra tokens
Description:
Fixes part of #179.
Changes made:

list abc and list recurring extra now throw an error instead of silently falling through to the full list or recurring list
budget reset extra and budget history history (and any extra tokens after reset/history) now throw a specific usage error instead of the wrong "budget requires a number" message
Updated UG error cases for list and budget reset/budget history to reflect new behaviour

Testing done:

list abc → Invalid list option. Usage: list OR list recurring
list recurring extra → Invalid list option. Usage: list OR list recurring
budget reset extra → Usage: budget reset
budget history history → Usage: budget history 