### PR TITLE
fix: restore budget history on undo

### DIFF
--- a/src/main/java/seedu/duke/ExpenseList.java
+++ b/src/main/java/seedu/duke/ExpenseList.java
@@ -195,17 +195,22 @@ public class ExpenseList {
     }
 
     /**
-     * Replaces the current expenses and budget with the given snapshot data.
+     * Replaces the current expenses, budget, and budget history with the given snapshot data.
      * Used by UndoManager to restore a previous state.
      *
      * @param restoredExpenses the list of expenses to restore
      * @param restoredBudget the budget amount to restore
+     * @param restoredBudgetHistory budget history entries to restore (copied defensively)
      */
-    public void restoreFrom(ArrayList<Expense> restoredExpenses, double restoredBudget) {
+    public void restoreFrom(ArrayList<Expense> restoredExpenses, double restoredBudget,
+            ArrayList<String> restoredBudgetHistory) {
         assert restoredExpenses != null : "Restored expenses should not be null";
+        assert restoredBudgetHistory != null : "Restored budget history should not be null";
         this.expenses = new ArrayList<>(restoredExpenses);
         this.budget = restoredBudget;
-        logger.info("Expenses restored: " + expenses.size() + " entries, budget=" + budget);
+        this.budgetHistory = new ArrayList<>(restoredBudgetHistory);
+        logger.info("Expenses restored: " + expenses.size() + " entries, budget=" + budget
+                + ", budgetHistoryEntries=" + budgetHistory.size());
     }
 
     // @@author pranavjana

--- a/src/main/java/seedu/duke/UndoManager.java
+++ b/src/main/java/seedu/duke/UndoManager.java
@@ -18,6 +18,7 @@ public class UndoManager {
 
     private ArrayList<Expense> snapshot;
     private double snapshotBudget;
+    private ArrayList<String> snapshotBudgetHistory;
     private boolean hasSnapshot;
 
     /**
@@ -26,11 +27,12 @@ public class UndoManager {
     public UndoManager() {
         this.snapshot = null;
         this.snapshotBudget = 0.0;
+        this.snapshotBudgetHistory = null;
         this.hasSnapshot = false;
     }
 
     /**
-     * Saves a deep copy of the current expense list and budget as a snapshot.
+     * Saves a deep copy of the current expense list, budget, and budget history as a snapshot.
      * Overwrites any previously stored snapshot.
      *
      * @param expenses the expense list to snapshot
@@ -40,8 +42,10 @@ public class UndoManager {
 
         snapshot = deepCopyExpenses(expenses.getExpenses());
         snapshotBudget = expenses.getBudget();
+        snapshotBudgetHistory = new ArrayList<>(expenses.getBudgetHistory());
         hasSnapshot = true;
-        logger.info("Snapshot saved: " + snapshot.size() + " expenses, budget=" + snapshotBudget);
+        logger.info("Snapshot saved: " + snapshot.size() + " expenses, budget=" + snapshotBudget
+                + ", budgetHistoryEntries=" + snapshotBudgetHistory.size());
     }
 
     /**
@@ -59,9 +63,10 @@ public class UndoManager {
             return false;
         }
 
-        expenses.restoreFrom(snapshot, snapshotBudget);
+        expenses.restoreFrom(snapshot, snapshotBudget, snapshotBudgetHistory);
         hasSnapshot = false;
         snapshot = null;
+        snapshotBudgetHistory = null;
         logger.info("Snapshot restored successfully.");
         return true;
     }

--- a/src/test/java/seedu/duke/command/UndoCommandTest.java
+++ b/src/test/java/seedu/duke/command/UndoCommandTest.java
@@ -101,6 +101,32 @@ class UndoCommandTest {
     }
 
     @Test
+    void execute_undoRestoresBudgetHistory_afterSecondSetBudget() {
+        expenses.setBudget(500.00);
+        undoManager.saveSnapshot(expenses);
+        expenses.setBudget(1000.00);
+        assertEquals(2, expenses.getBudgetHistory().size());
+
+        new UndoCommand(undoManager).execute(expenses, ui);
+
+        assertEquals(500.00, expenses.getBudget(), 0.01);
+        assertEquals(1, expenses.getBudgetHistory().size());
+    }
+
+    @Test
+    void execute_undoRestoresBudgetHistory_afterReset() {
+        expenses.setBudget(500.00);
+        undoManager.saveSnapshot(expenses);
+        expenses.resetBudget();
+        assertEquals(2, expenses.getBudgetHistory().size());
+
+        new UndoCommand(undoManager).execute(expenses, ui);
+
+        assertEquals(500.00, expenses.getBudget(), 0.01);
+        assertEquals(1, expenses.getBudgetHistory().size());
+    }
+
+    @Test
     void execute_undoAfterEdit_restoresOriginalExpense() {
         expenses.addExpense(new Expense("Lunch", 10.00, "Food", LocalDate.now()));
         undoManager.saveSnapshot(expenses);


### PR DESCRIPTION
Summary
Fixes a bug where undo restored the budget amount but not the budget history list, so budget history could show extra or wrong lines after undoing a budget change or budget reset. Snapshots now include a copy of budget history, and restore replaces the live history to match the pre-command state.

Root cause
UndoManager.saveSnapshot only stored expenses and getBudget(). ExpenseList.restoreFrom updated expenses and budget but did not touch budgetHistory, leaving stale entries that no longer matched the restored budget.

Changes
UndoManager: Store new ArrayList<>(expenses.getBudgetHistory()) on save; pass it into restore; clear snapshot fields after undo.
ExpenseList.restoreFrom: Add parameter for restored budget history; assign this.budgetHistory = new ArrayList<>(restoredBudgetHistory).
UndoCommandTest: Cover undo after a second setBudget and undo after budget reset (history size and budget).

Notes
Savings goal is unchanged; this PR only aligns undo with budget history.
Developer guide / PlantUML undo diagrams still describe the old restoreFrom signature; they can be updated in a small follow-up if you want docs in sync.