### PR TITLE
docs: align UG/DG with undo, budget history, and list/budget errors

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -954,10 +954,10 @@ As part of v2.0, all commands were audited to ensure no user input can cause an 
 | `add` | Missing `d/` throws error; missing `a/` throws error; zero/negative amount throws error; non-numeric amount throws error |
 | `delete` | Non-integer index throws error; missing index throws error |
 | `edit` | Non-integer index; empty/blank description; zero/negative amount; no fields provided; duplicate flags all throw errors |
-| `budget` | Empty input throws error; non-numeric amount throws error | | `list` | Extra tokens after `list` or unrecognised sub-command throws error |
+| `budget` | Empty input throws error; non-numeric amount throws error; `Infinity` and `NaN` values rejected as invalid amounts |
+| `list` | Extra tokens after `list` or unrecognised sub-command throws error |
 | `budget reset` | Extra tokens after `reset` throws error |
 | `budget history` | Extra tokens after `history` throws error |
-| `budget` | `Infinity` and `NaN` values now rejected as invalid amounts |
 
 #### Design considerations
 
@@ -1126,7 +1126,7 @@ If the list is already empty, `ClearCommand` shows `No expenses to clear.` witho
 
 ### Undo Feature
 
-The undo feature restores the expense list to its state before the last mutating command:
+The undo feature restores saved data (expenses, current budget, and budget history) to its state before the last mutating command:
 
 ```
 undo
@@ -1136,11 +1136,11 @@ undo
 
 1. `SpendTrack` owns an `UndoManager` instance, created on startup.
 2. Before every mutating command executes (except `undo` itself), `SpendTrack` calls `UndoManager.saveSnapshot(expenses)`.
-3. `saveSnapshot()` creates a deep copy of all `Expense` objects in the list and stores the current budget value. This ensures the snapshot is independent of future mutations.
+3. `saveSnapshot()` creates a deep copy of all `Expense` objects in the list, stores the current budget value, and copies the budget history list. This ensures the snapshot is independent of future mutations.
 4. When the user enters `undo`, `Parser` creates an `UndoCommand` with a reference to the `UndoManager`.
 5. `UndoCommand.execute()` calls `UndoManager.undo(expenses)`.
 6. `undo()` checks if a snapshot exists. If not, it returns `false` and the command prints `Nothing to undo.`
-7. If a snapshot exists, it calls `ExpenseList.restoreFrom()` which replaces the internal expense list and budget with the snapshot data. The snapshot is then consumed (set to `null`), preventing a second undo.
+7. If a snapshot exists, it calls `ExpenseList.restoreFrom()` which replaces the internal expense list, budget, and budget history with the snapshot data. The snapshot is then consumed (set to `null`), preventing a second undo.
 8. Because `mutatesData()` returns `true`, `Storage.save()` persists the restored state.
 
 The following sequence diagram shows the undo flow:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -361,6 +361,9 @@ If no expenses have been added:
  No expenses recorded yet.
 ```
 
+Error cases:
+- `list foo` or any second word other than `recurring` → `Invalid list option. Usage: list OR list recurring`
+
 ---
 
 ### Listing recurring expenses: `list recurring`
@@ -500,6 +503,7 @@ ____________________________________________________________
 
 Error cases:
 - `budget reset` when no budget is set → `No budget to reset.`
+- `budget reset` with extra text (e.g. `budget reset please`) → `Usage: budget reset`
 
 Note: A reset entry is recorded in budget history as `RESET ($0.00)`
 so you can track when your budget was cleared.
@@ -527,6 +531,9 @@ If no budget has ever been set:
 ```
  No budget history recorded. 
 ```
+
+Error cases:
+- `budget history` with extra text (e.g. `budget history please`) → `Usage: budget history`
 
 ---
 
@@ -566,7 +573,7 @@ Format: `clear`
 
 - You must type `yes` (case-insensitive) to confirm. Any other input cancels.
 - If the expense list is already empty, shows a message without prompting.
-- A `clear` operation can be reversed with the `undo` command immediately after (undo restores the full expense list and budget state).
+- A `clear` operation can be reversed with the `undo` command immediately after (undo restores the full expense list, current budget, and budget history as they were before that command).
 
 Example:
 ```
@@ -598,13 +605,20 @@ ____________________________________________________________
 
 ### Undoing the last command: `undo`
 
-Restores the expense list to its state before the last mutating command (`add`, `delete`, `edit`, `clear`).
+Restores saved data to its state immediately before the last **mutating** command.
 
 Format: `undo`
 
+Mutating commands (each overwrites the one undo slot when run):
+
+- `add`, `delete`, `edit`, `clear`
+- `budget` / `b` (set a new monthly limit)
+- `budget reset`
+
+Undo restores **expenses**, the **current budget amount**, and the **budget history log** together, so undoing a second `budget` or a `budget reset` also reverts the history entries that command had added.
+
 - Only single-level undo is supported. A second consecutive `undo` prints `Nothing to undo.`
-- Non-mutating commands (`list`, `help`, `summary`, etc.) do not affect the undo history.
-- Budget state is also restored.
+- Non-mutating commands (`list`, `help`, `summary`, `budget history`, etc.) do not affect the undo history.
 
 Example:
 ```


### PR DESCRIPTION
Summary
Updates the User Guide and Developer Guide so they match current behaviour: undo applies to budget / b and budget reset, and it restores expenses, current budget, and budget history together. Also documents parser errors for invalid list arguments and extra tokens on budget reset / budget history, and fixes a broken markdown row in the DG validation table.

User Guide
list: Document list <anything-but-recurring> → Invalid list option. Usage: list OR list recurring.
budget reset / budget history: Document trailing garbage → Usage: budget reset / Usage: budget history.
clear: Clarify that undo restores list, budget, and budget history.
undo: List all mutating commands (including budget set/reset), explain budget history rollback, and note budget history is non-mutating for undo.

Developer Guide
Undo feature: Snapshot/restore description now includes budget history.
Input validation table: Split merged budget | list row; combine duplicate budget rows into one.