### PR TITLE
test: extend coverage for list, budget parser, budget reset/history

### DIFF
--- a/src/test/java/seedu/duke/InputValidationTest.java
+++ b/src/test/java/seedu/duke/InputValidationTest.java
@@ -103,6 +103,30 @@ public class InputValidationTest {
                 Parser.parse("budget 500"));
     }
 
+    @Test
+    void parse_budgetNaN_throwsException() {
+        assertThrows(SpendTrackException.class, () ->
+                Parser.parse("budget NaN"));
+    }
+
+    @Test
+    void parse_budgetInfinity_throwsException() {
+        assertThrows(SpendTrackException.class, () ->
+                Parser.parse("budget Infinity"));
+    }
+
+    @Test
+    void parse_budgetResetWithExtra_throwsException() {
+        assertThrows(SpendTrackException.class, () ->
+                Parser.parse("budget reset now"));
+    }
+
+    @Test
+    void parse_budgetHistoryWithExtra_throwsException() {
+        assertThrows(SpendTrackException.class, () ->
+                Parser.parse("budget history all"));
+    }
+
     // @@author
 
     // ── Edit command validation ───────────────────────────────────────────────
@@ -244,6 +268,12 @@ public class InputValidationTest {
     @Test
     void parse_listAliasL_returnsListCommand() throws SpendTrackException {
         assertTrue(Parser.parse("l") instanceof ListCommand);
+    }
+
+    @Test
+    void parse_listInvalidSubcommand_throwsException() {
+        assertThrows(SpendTrackException.class, () ->
+                Parser.parse("list foo"));
     }
 
     // @@author

--- a/src/test/java/seedu/duke/ListCommandTest.java
+++ b/src/test/java/seedu/duke/ListCommandTest.java
@@ -16,6 +16,11 @@ public class ListCommandTest {
     }
 
     @Test
+    public void listCommand_recurringMode_isNotExit() {
+        assertFalse(new ListCommand(true).isExit());
+    }
+
+    @Test
     public void listCommand_executesOnEmptyList() {
         ExpenseList expenses = new ExpenseList();
         // Just checks it doesn't throw on empty list

--- a/src/test/java/seedu/duke/command/BudgetResetHistoryCommandTest.java
+++ b/src/test/java/seedu/duke/command/BudgetResetHistoryCommandTest.java
@@ -1,0 +1,67 @@
+// @@author AbhijitBalajee
+package seedu.duke.command;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seedu.duke.ExpenseList;
+import seedu.duke.SpendTrackException;
+import seedu.duke.Ui;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link BudgetResetCommand} and {@link BudgetHistoryCommand}.
+ */
+class BudgetResetHistoryCommandTest {
+
+    private ExpenseList expenses;
+    private Ui ui;
+
+    @BeforeEach
+    void setUp() {
+        expenses = new ExpenseList();
+        ui = new Ui();
+    }
+
+    @Test
+    void resetCommand_mutatesData_returnsTrue() {
+        assertTrue(new BudgetResetCommand().mutatesData());
+    }
+
+    @Test
+    void historyCommand_mutatesData_returnsFalse() {
+        assertFalse(new BudgetHistoryCommand().mutatesData());
+    }
+
+    @Test
+    void reset_withNoBudget_throwsException() {
+        assertThrows(SpendTrackException.class,
+                () -> new BudgetResetCommand().execute(expenses, ui));
+    }
+
+    @Test
+    void reset_withBudget_clearsBudgetAndAppendsHistory() throws SpendTrackException {
+        expenses.setBudget(100.00);
+        int historySize = expenses.getBudgetHistory().size();
+        new BudgetResetCommand().execute(expenses, ui);
+        assertEquals(0.0, expenses.getBudget(), 0.001);
+        assertFalse(expenses.hasBudget());
+        assertEquals(historySize + 1, expenses.getBudgetHistory().size());
+    }
+
+    @Test
+    void historyCommand_emptyHistory_doesNotThrow() {
+        assertDoesNotThrow(() -> new BudgetHistoryCommand().execute(expenses, ui));
+    }
+
+    @Test
+    void historyCommand_withHistory_doesNotThrow() throws SpendTrackException {
+        expenses.setBudget(50.00);
+        assertDoesNotThrow(() -> new BudgetHistoryCommand().execute(expenses, ui));
+    }
+}
+// @@author


### PR DESCRIPTION
Summary
Adds tests for Abhijit’s features where coverage was thin: Parser validation for budget (non-finite amounts, trailing tokens on reset / history), invalid list arguments, ListCommand recurring mode isExit, and direct tests for BudgetResetCommand / BudgetHistoryCommand.

Changes
InputValidationTest: budget NaN, budget Infinity, budget reset <extra>, budget history <extra>, list foo.
**ListCommandTest:** new ListCommand(true).isExit()` is false.
BudgetResetHistoryCommandTest: mutatesData; reset throws when no budget; reset clears budget and appends history; history command does not throw (empty / with history).
Notes
Does not duplicate BudgetSubCentTest (minimum $0.01 budget) or existing BudgetCommandTest / EditCommandTest / UndoCommandTest coverage.