### PR TITLE
docs: update PPP with v2.1 contributions

### DIFF
--- a/docs/team/afshalg.md
+++ b/docs/team/afshalg.md
@@ -23,16 +23,22 @@ SpendTrack is a CLI expense tracker for NUS students who prefer typing over clic
 - **Fixed output formatting** (v2.0): Fixed `search`, `sort`, `last`, `top`, `report`, `month` commands to use `ui.showMessage()` instead of `System.out.println()` for consistent Ui borders across all commands.
 - **Updated help command** (v2.0): Rewrote `Ui.showHelp()` to list all 25+ commands with aliases and descriptions, replacing the outdated v1.0 help output.
 - **Pre-PE-D input hardening** (v2.1): Fixed nine functionality bugs across parsing, date validation, and command input handling, each covered by a dedicated JUnit test class. Changes include: graceful EOF handling in `Ui.readCommand()` (no more Java stack trace when stdin closes); rejection of `NaN`/`Infinity` in `add`, `edit`, `budget`, and `goal` amounts; strict `YYYY-MM` format validation with 1–12 month range for `month` and `report`; alignment of the `clear` confirmation prompt with the actual undo behaviour; strict calendar date parsing for `DD-MM-YYYY` to reject impossible dates like `29-02-2025`; duplicate flag detection for `filter`; rejection of `|` in descriptions to prevent silent save file corruption; rejection of empty `search` keywords; minimum `$0.01` enforcement for `budget` to avoid sub-cent rounding.
+- **PE-D bug fixes and input validation** (v2.1): Triaged 20 PE-D bug reports, assigned labels/milestones/owners for all issues. Fixed bugs assigned to me: misleading error for unrecognised flag prefixes like `da/today` (#219); UG jar filename case mismatch (#220); summary percentage column alignment (#229). Also fixed: summary command silently accepting extra arguments; sub-cent amounts below `$0.01` accepted and displayed as `$0.00` in `add` and `edit`.
+- **Case-insensitive flags** (v2.1): Made `TOKEN_SPLIT_REGEX` and all `startsWith` checks in `parseAddCommand` and `parseEditCommand` case-insensitive, so `D/`, `A/`, `C/`, `DATE/`, `RECURRING/` work the same as lowercase. Consistent with case-insensitive command words.
+- **Flag-in-description validation** (v2.1): Added `validateDescriptionFlags()` to reject descriptions containing flag prefixes (`a/`, `d/`, `c/`, `date/`, `recurring/`) that would cause ambiguous parsing. Non-flag slashes like `I/O`, `w/`, `N/A`, `24/7` are accepted. Applied consistently to both `add` and `edit`.
 
 ### Contributions to the UG
 
 - Add expense section with date formats, category normalisation, and examples
 - Delete expense section with error cases
 - Category summary section with column explanations
-- Command aliases table
+- Command aliases table with note on case-insensitive commands and flags
 - FAQ and command summary table
 - Fixed UG error messages to match actual app output (bye, delete, remaining, edit)
 - Updated help expected output to match all v2.0 commands
+- Documented new error cases: unrecognised tokens, flag-in-description, amount cap, sub-cent minimum
+- Fixed command summary table `c/CAT` shown as required when it is optional
+- Fixed UG jar filename from `spendtrack.jar` to `SpendTrack.jar`
 
 ### Contributions to the DG
 
@@ -49,13 +55,8 @@ SpendTrack is a CLI expense tracker for NUS students who prefer typing over clic
   - Class diagram: Parser, DateParser, AddCommand, SummaryCommand, Expense, ExpenseList
   - Object diagram: SummaryCommand state snapshot showing category maps
 - Cleaned up DG: removed duplicate Remaining/Help/Search sections, fixed heading levels, removed orphaned content, removed duplicate manual testing sections
-
-- UML diagrams:
-    - Sequence diagram: add command flow with DateParser and category normalisation
-    - Sequence diagram: DateParser internal format fallthrough
-    - Sequence diagram: SummaryCommand execution with enhanced stats
-    - Class diagram: Parser, DateParser, AddCommand, SummaryCommand, Expense, ExpenseList
-    - Object diagram: SummaryCommand state snapshot showing category maps
+- Updated DG add format and parsing description for case-insensitive flags and flag-in-description validation
+- Fixed object diagram: removed primitive `double` as standalone object, added links from SummaryCommand to Expense objects
 - Updated user stories, glossary, and manual testing appendix
 
 
@@ -69,7 +70,9 @@ SpendTrack is a CLI expense tracker for NUS students who prefer typing over clic
 - Fixed build-breaking issues from teammates' PRs (PRs #23, #24, #27, #28)
 - Enabled assertions in `build.gradle` for the entire team (PR #31)
 - Fixed critical release-blocking bugs: wired 4 missing commands into Parser, fixed output formatting across 6 commands, updated help and expected test output
+- Triaged all 20 PE-D bug reports: assigned owners, labels (severity + type), and v2.1 milestone to every issue
+- Removed misplaced `docs/diagrams/images/` folder created by a teammate
 
 ### Community
 
-- Reviewed PRs: #15, #20, #21, #25, #26, #84, #87, #90, #94, #95, #98, #102, #181, #184
+- Reviewed PRs: #15, #20, #21, #25, #26, #84, #87, #90, #94, #95, #98, #102, #181, #184, #254


### PR DESCRIPTION
## Summary

- Add v2.1 enhancements: PE-D triage, case-insensitive flags, flag-in-description validation, sub-cent rejection
- Add v2.1 UG contributions: new error cases, command summary fix, jar filename fix
- Add v2.1 DG contributions: object diagram fix, add format and parsing description updates
- Add v2.1 team tasks: PE-D triage of all 20 issues, misplaced image folder cleanup
- Remove duplicate UML diagram listing
- Add PR #254 to reviewed PRs

Part of #104