### PR TITLE
docs: fix UG/DG mismatches with actual runtime output

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -562,7 +562,7 @@ The `search` command allows users to find expenses based on a keyword in the des
 3. `SearchCommand.execute()` iterates through all expenses using `getExpenses()`.
 4. For each expense, `.getDescription().toLowerCase().contains(keyword.toLowerCase())` is used for case-insensitive substring matching.
 5. Matching expenses are printed with a running count.
-6. If no matches are found, `No matches found.` is shown.
+6. If no matches are found, the `Search results:` header is still printed followed by ` No matches found.` on the next line.
 
 The following activity diagram shows the logic of the search feature:
 
@@ -725,15 +725,15 @@ The following activity diagram shows the logic of the report feature:
 
 **Aspect: Error handling for malformed input**
 
-- **Current approach:** A broad `catch (Exception e)` catches any parsing failure and shows `Usage: report <YYYY-MM>`.
-    - Pros: Simple and robust. Any malformed input (wrong format, missing parts, non-numeric) is caught cleanly.
-    - Cons: Catches too broadly — unexpected errors may be silently swallowed.
+- **Current approach:** `Parser.validateYearMonth()` validates the input against a strict `\d{4}-\d{2}` regex before parsing, and checks the month is in `01`..`12`. An empty argument throws `Usage: report <YYYY-MM>`; a malformed argument throws `Invalid format. Usage: report <YYYY-MM> (e.g. 2026-03)`; a month out of range throws `Invalid month. Use YYYY-MM with month between 01 and 12.`
+    - Pros: Precise error messages help the user correct the exact problem. Rejects `2026-13`, `2026-00`, and `03-2026` deterministically without relying on exception-based flow.
+    - Cons: Slightly more code than a single broad catch.
 
-- **Alternative:** Validate the format explicitly with a regex before parsing.
-    - Pros: More precise error detection. Can give more specific error messages.
-    - Cons: Adds complexity for a simple format check.
+- **Alternative:** A broad `catch (Exception e)` that shows one generic usage message.
+    - Pros: Fewer branches in the parser.
+    - Cons: Users cannot distinguish between "wrong format" and "month out of range", making error messages less actionable.
 
-The broad catch was chosen for simplicity in v1.0.
+The explicit validation approach was adopted in v2.0.1 PE-D hardening (issue #178) to reject ambiguous year-month inputs that earlier silently passed.
 
 ---
 
@@ -1348,8 +1348,8 @@ SpendTrack helps students track expenses faster than a typical GUI app. Users ca
 ### Launch
 
 1. Ensure Java 17 is installed.
-2. Download the latest `spendtrack.jar` from the GitHub releases page.
-3. Open a terminal, navigate to the folder containing the JAR, and run: `java -jar spendtrack.jar`
+2. Download the latest `SpendTrack.jar` from the GitHub releases page.
+3. Open a terminal, navigate to the folder containing the JAR, and run: `java -jar SpendTrack.jar`
 
 ### Adding an expense
 
@@ -1458,7 +1458,7 @@ SpendTrack helps students track expenses faster than a typical GUI app. Users ca
 4. Enter `report 2026-04` for a month with no expenses.
 5. Expected: `No expenses found for 2026-04`
 6. Enter `report abc`
-7. Expected: `Usage: report <YYYY-MM>`
+7. Expected: `Invalid format. Usage: report <YYYY-MM> (e.g. 2026-03)`
 
 ### Viewing expenses by month
 1. Add expenses with explicit dates across different months.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -64,7 +64,7 @@ Error cases:
 - `add d/Coffee a/5` (missing category) behaves as if `c/Uncategorised` was provided — defaults are applied silently.
 - `add d/Coffee a/NaN c/Food` or `a/Infinity` → `Amount must be a finite number. Usage: a/<amount>`
 - `add d/Coffee a/-5 c/Food` → `Amount must be a positive number. Usage: a/<amount>`
-- `add d/Coffee a/abc c/Food` → `Amount must be a number. Usage: a/<amount>`
+- `add d/Coffee a/abc c/Food` → `Amount is required and must be greater than 0. Usage: a/<amount>`
 - `add d/Coffee d/Tea a/5 c/Food` (duplicate flag) → `Duplicate 'd/' detected. Please provide only one description.`
 - `add d/Alice|Bob a/20 c/Food` → `Description cannot contain '|' (reserved for save file format). Please use a different character.`
 - `add d/T a/5 c/Food date/29-02-2025` (Feb 29 on a non-leap year) → `Invalid date format. Accepted: YYYY-MM-DD, DD-MM-YYYY, 'today', 'yesterday'.`
@@ -228,7 +228,9 @@ ____________________________________________________________
  Welcome to SpendTrack!
  ...
 ____________________________________________________________
- Last recorded expense: Coffee | $3.50 | Food | 2026-03-22
+ Last recorded expense:
+   Coffee | $3.50 | Food | 2026-03-22
+____________________________________________________________
 ```
 
 This helps you avoid accidentally logging the same expense twice.
@@ -281,7 +283,7 @@ Error cases:
 - `filter from/2026-03-01 to/2026-03-05 to/2026-03-31` (duplicate `to/`) → `Duplicate 'to/' detected. Please provide only one end date.`
 - `filter from/2026-03-01 to/2026-03-31 c/Food c/Transport` (duplicate `c/`) → `Duplicate 'c/' detected. Please provide only one category.`
 - `filter from/2026-03-01 to/2026-03-31 c/Food|hack` → `Category cannot contain '|'.`
-- `filter from/2026-03-01 to/2026-03-31 garbage` → `Unknown filter option: 'garbage'.`
+- `filter from/2026-03-01 to/2026-03-31 garbage` → `Unknown filter option: 'garbage'. Usage: filter from/YYYY-MM-DD to/YYYY-MM-DD [c/CATEGORY]`
 
 ---
 
@@ -362,7 +364,12 @@ ____________________________________________________________
 
 If no expenses have been added:
 ```
+____________________________________________________________
+ Your Expenses
+____________________________________________________________
  No expenses recorded yet.
+ Hint: Use 'add d/DESCRIPTION a/AMOUNT c/CATEGORY' to add one.
+____________________________________________________________
 ```
 
 Error cases:
@@ -788,7 +795,8 @@ ____________________________________________________________
 ```
 
 Error cases:
-- `report 03-2026` or `report abc` → `Usage: report <YYYY-MM>`
+- `report` (no argument) → `Usage: report <YYYY-MM>`
+- `report 03-2026` or `report abc` → `Invalid format. Usage: report <YYYY-MM> (e.g. 2026-03)`
 - `report 2026-13` or `report 2026-00` (month out of range) → `Invalid month. Use YYYY-MM with month between 01 and 12.`
 
 ---
@@ -823,7 +831,8 @@ ____________________________________________________________
 ```
 
 Error cases:
-- `month abc` or `month 03-2026` → `Usage: month <YYYY-MM>`
+- `month` (no argument) → `Usage: month <YYYY-MM>`
+- `month abc` or `month 03-2026` → `Invalid format. Usage: month <YYYY-MM> (e.g. 2026-03)`
 - `month 2026-13` or `month 2026-00` (month out of range) → `Invalid month. Use YYYY-MM with month between 01 and 12.`
 
 ---
@@ -912,6 +921,7 @@ ____________________________________________________________
 If no matches are found:
 ```
 ____________________________________________________________
+ Search results:
  No matches found.
 ____________________________________________________________
 ```
@@ -1009,7 +1019,7 @@ ____________________________________________________________
   budget history                                                           -- view budget history
   remaining                                                                -- show remaining
   edit INDEX [d/DESC] [a/AMT] [c/CAT] [date/DATE] [recurring/true|false]   -- edit expense
-  filter from/DATE to/DATE [c/CATEGORY]                                  -- filter by date range and/or category
+  filter from/DATE to/DATE [c/CATEGORY]                                    -- filter by date range and/or category
   find INDEX                                                               -- view expense details
   find d/KEYWORD                                                           -- search by description keyword
   search KEYWORD                                                           -- search by keyword


### PR DESCRIPTION
## Summary

Comprehensive audit of UG and DG against the actual submitted JAR. Found 12 places where documentation did not match runtime behavior. All fixes are doc-only — no code changed.

## UG fixes (8)

- `add a/abc` error: UG claimed `Amount must be a number...`, actual is `Amount is required and must be greater than 0...`
- `filter ... garbage` error: added the `Usage:` suffix the code actually prints
- Startup reminder: two-line indented format + closing border to match `Ui` output
- Empty `list`: added box borders and the `Hint:` line that actually prints
- `report` errors: split into no-arg vs bad-format cases with accurate messages
- `month` errors: same split as `report`
- `search` no-match: added the `Search results:` header that always prints
- Help example block: filter row padded +2 spaces to match `showHelp()` output

## DG fixes (4)

- Manual testing instructions: `spendtrack.jar` → `SpendTrack.jar` (2 places)
- Report error-handling design section: updated from outdated broad-catch description to current `validateYearMonth()` regex-validation approach
- Manual test for `report abc`: corrected expected output
- Search design section: noted that `Search results:` header is printed even when no matches

## Test plan

- [x] Built submitted JAR from `tp-submission/`, ran every UG example input, captured outputs
- [x] Diffed runtime output against every UG `Expected output:` block
- [x] Tested every documented error case from UG sections (~30 cases)
- [x] Verified all 22 commands appear in `Ui.showHelp()` output
- [x] Verified `budget status` is NOT a command (Parser.java:657-686 rejects it)
- [x] Read all 1098 lines of UG and all 1495 lines of DG (skipping diagrams)